### PR TITLE
New events now require event_type (name) instead of id. Other events

### DIFF
--- a/lambdas/events/db.js
+++ b/lambdas/events/db.js
@@ -14,17 +14,17 @@ const pool = new Pool({
 });
 
 const queries = {
-  getEvent: `SELECT events.uuid, event_types.uuid as event_type_id, users.uuid as user_id, payload, idempotency_key
+  getEvent: `SELECT events.uuid, event_types.uuid as event_type_id, event_types.name as event_type_name, users.uuid as user_id, payload, idempotency_key
     FROM events 
     JOIN event_types ON events.event_type_id = event_types.id
     JOIN users ON events.user_id = users.id
     WHERE events.uuid = $1`,
   hasUniqueIdempotencyKey: `SELECT uuid FROM events WHERE idempotency_key = $1`,
-  getTopicArn: `SELECT sns_topic_arn FROM event_types WHERE uuid = $1`,
+  getTopicArn: `SELECT sns_topic_arn FROM event_types WHERE service_id = $1 AND name = $2`,
   addEvent: `INSERT INTO events (uuid, event_type_id, user_id, payload, idempotency_key)
     VALUES ($1, $2, $3, $4, $5)
     RETURNING *`,
-  listEvents: `SELECT events.uuid, event_types.uuid as event_type_id, users.uuid as user_id, payload, idempotency_key
+  listEvents: `SELECT events.uuid, event_types.uuid as event_type_id, event_types.name as event_type_name, users.uuid as user_id, payload, idempotency_key
       FROM events 
       JOIN event_types ON events.event_type_id = event_types.id
       JOIN users ON events.user_id = users.id

--- a/lambdas/events/index.js
+++ b/lambdas/events/index.js
@@ -28,7 +28,7 @@ exports.handler = async (event) => {
   if (eventUuid && httpMethod === "GET") {
     return await getEvent(eventUuid);
   } else if (httpMethod === "POST") {
-    return await createEvent(userUuid, body);
+    return await createEvent(serviceUuid, userUuid, body);
   } else if (httpMethod === "GET") {
     return await listEvents(userUuid);
   }

--- a/lambdas/events/utils.js
+++ b/lambdas/events/utils.js
@@ -45,7 +45,18 @@ const isValidUser = async (userUuid) => {
   return response.rows.length > 0;
 };
 
+const getEventTypeInfo = async (name) => {
+  const text =
+    "SELECT id, uuid, sns_topic_arn FROM event_types WHERE name = $1";
+  const values = [name];
+
+  const response = await db.query(text, values);
+  let responseBody = response.rows[0];
+  return responseBody;
+};
+
 module.exports.newResponse = newResponse;
 module.exports.isValidService = isValidService;
 module.exports.isValidUser = isValidUser;
 module.exports.uuidToId = uuidToId;
+module.exports.getEventTypeInfo = getEventTypeInfo;


### PR DESCRIPTION
- Routes now return event_type_name and event_type_id
- "Create New Event" requires event type name instead of event type id
- Cleaned up console.logs

Co-authored-by: Armando Mota <armandomotagt@gmail.com>
Co-authored-by: Juan Palma <juanpedropalma@hotmail.com>
Co-authored-by: Kayl Thomas <kaylthomas607@gmail.com>